### PR TITLE
Implement LogLoss metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/.test_coverage.dart
 
 .DS_Store
 */**/.DS_Store
+flutter-sdk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16.17.14
+- Added `MetricType.logLoss` and `LogLossMetric` for evaluating probabilistic
+  binary classifiers
+
 ## 16.17.13
 - Added Decision Tree web demo using Web Assembly
 

--- a/lib/src/metric/classification/log_loss_metric.dart
+++ b/lib/src/metric/classification/log_loss_metric.dart
@@ -1,0 +1,28 @@
+import 'package:ml_algo/src/helpers/validate_matrix_columns.dart';
+import 'package:ml_algo/src/metric/metric.dart';
+import 'package:ml_linalg/matrix.dart';
+import 'dart:math' as math;
+
+class LogLossMetric implements Metric {
+  const LogLossMetric({this.eps = 1e-15});
+
+  final double eps;
+
+  double _clip(double p) => p < eps ? eps : (p > 1.0 - eps ? 1.0 - eps : p);
+
+  @override
+  double getScore(Matrix predictedLabels, Matrix origLabels) {
+    validateMatrixColumns([predictedLabels, origLabels]);
+
+    final preds = predictedLabels.toVector();
+    final orig = origLabels.toVector();
+
+    var sum = 0.0;
+    for (var i = 0; i < preds.length; i++) {
+      final p = _clip(preds[i]);
+      final y = orig[i];
+      sum += y == 1 ? -math.log(p) : -math.log(1.0 - p);
+    }
+    return sum / preds.length;
+  }
+}

--- a/lib/src/metric/metric_factory_impl.dart
+++ b/lib/src/metric/metric_factory_impl.dart
@@ -1,6 +1,7 @@
 import 'package:ml_algo/src/metric/classification/accuracy.dart';
 import 'package:ml_algo/src/metric/classification/precision.dart';
 import 'package:ml_algo/src/metric/classification/recall.dart';
+import 'package:ml_algo/src/metric/classification/log_loss_metric.dart';
 import 'package:ml_algo/src/metric/metric.dart';
 import 'package:ml_algo/src/metric/metric_factory.dart';
 import 'package:ml_algo/src/metric/metric_type.dart';
@@ -27,6 +28,9 @@ class MetricFactoryImpl implements MetricFactory {
 
       case MetricType.recall:
         return const RecallMetric();
+
+      case MetricType.logLoss:
+        return const LogLossMetric();
 
       default:
         throw UnsupportedError('Unsupported metric type $type');

--- a/lib/src/metric/metric_type.dart
+++ b/lib/src/metric/metric_type.dart
@@ -100,4 +100,7 @@ enum MetricType {
   /// better the prediction's quality is. The metric produces scores within the
   /// range [0, 1]
   recall,
+
+  /// Binary cross-entropy (a.k.a. log-loss)
+  logLoss,
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ml_algo
 description: Machine learning algorithms, Machine learning models performance evaluation functionality
-version: 16.17.13
+version: 16.17.14
 homepage: https://github.com/gyrdym/ml_algo
 
 environment:

--- a/test/metric/classification/log_loss_metric_test.dart
+++ b/test/metric/classification/log_loss_metric_test.dart
@@ -1,0 +1,28 @@
+import 'package:ml_algo/src/metric/classification/log_loss_metric.dart';
+import 'package:ml_linalg/matrix.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LogLossMetric', () {
+    const metric = LogLossMetric();
+
+    test('perfect predictions → loss ≈ 0', () {
+      final yTrue = Matrix.column([1, 0, 1, 0]);
+      final yPred = Matrix.column([1.0, 0.0, 1.0, 0.0]);
+      expect(metric.getScore(yPred, yTrue), closeTo(0.0, 1e-12));
+    });
+
+    test('typical predictions', () {
+      final yTrue = Matrix.column([1, 0]);
+      final yPred = Matrix.column([0.9, 0.1]);
+      expect(metric.getScore(yPred, yTrue),
+          closeTo(0.10536051565782628, 1e-6)); // -ln(0.9)
+    });
+
+    test('probabilities are clipped', () {
+      final yTrue = Matrix.column([1, 0]);
+      final yPred = Matrix.column([0.0, 1.0]);
+      expect(metric.getScore(yPred, yTrue).isFinite, isTrue);
+    });
+  });
+}

--- a/test/metric/metric_factory_impl_test.dart
+++ b/test/metric/metric_factory_impl_test.dart
@@ -1,6 +1,7 @@
 import 'package:ml_algo/src/metric/classification/accuracy.dart';
 import 'package:ml_algo/src/metric/classification/precision.dart';
 import 'package:ml_algo/src/metric/classification/recall.dart';
+import 'package:ml_algo/src/metric/classification/log_loss_metric.dart';
 import 'package:ml_algo/src/metric/metric_factory_impl.dart';
 import 'package:ml_algo/src/metric/metric_type.dart';
 import 'package:ml_algo/src/metric/regression/mape.dart';
@@ -30,6 +31,10 @@ void main() {
 
     test('should create RecallMetric instance', () {
       expect(factory.createByType(MetricType.recall), isA<RecallMetric>());
+    });
+
+    test('should create LogLossMetric instance', () {
+      expect(factory.createByType(MetricType.logLoss), isA<LogLossMetric>());
     });
   });
 }


### PR DESCRIPTION
## Summary
- support binary log-loss evaluation with `LogLossMetric`
- register `MetricType.logLoss` in factory and enum
- provide unit tests for the new metric and factory case
- bump version to 16.17.14
- document addition in changelog
- ignore local `flutter-sdk` directory

## Testing
- `flutter-sdk/bin/dart test`

------
https://chatgpt.com/codex/tasks/task_e_68556bf005608321a7897870a1ebc43a